### PR TITLE
Added gir1.2-gpaste to requirements section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ v0.3 beta
 * Python 3
 * GTK 3.16+
 * GPaste 3.18+
+* On Ubuntu: gir1.2-gpaste-X.0 (e.g. gir1.2-gpaste-4.0 or gir1.2-gpaste-6.0)
 * OPTIONAL: GtkSourceView3
 
 ## Installation


### PR DESCRIPTION
This is not obvious problem, the error message was not event close to explaining what was needed to be done to fix it. Found explanation only in https://github.com/awamper/draobpilc/issues/5.