### PR TITLE
Allow setup.py to install PyGObject if it isn't already installed

### DIFF
--- a/draobpilc/__init__.py
+++ b/draobpilc/__init__.py
@@ -15,9 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gi
-gi.require_version('Gtk', '3.0')
-
 import os
 import locale
 import gettext

--- a/draobpilc/main.py
+++ b/draobpilc/main.py
@@ -23,7 +23,10 @@ import argparse
 from distutils.version import StrictVersion
 from dbus.exceptions import DBusException
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+
 from draobpilc import get_data_path
 from draobpilc import common
 from draobpilc import version
@@ -131,7 +134,7 @@ def uninstall_desktop_file():
         print(_('File "%s" doesn\'t exits.' % DESKTOP_FILE_PATH))
     else:
         os.remove(DESKTOP_FILE_PATH)
-    
+
     if not os.path.exists(DESKTOP_PREFS_FILE_PATH):
         print(_('File "%s" doesn\'t exits.' % DESKTOP_PREFS_FILE_PATH))
     else:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from draobpilc import version
 
 
 requirements = [
+    'pygobject',
     'humanize',
     'blinker',
     'python3-keybinder',


### PR DESCRIPTION
Fixes #24.

Accepting this pull request will both add PyGObject to the dependencies list in `setup.py` and fix a bug preventing the dependencies list from even being read if PyGObject isn't already installed.